### PR TITLE
add startupProbe support to mimir helm chart

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/admin-api/admin-api-dep.yaml
@@ -79,6 +79,8 @@ spec:
             {{- toYaml .Values.admin_api.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.admin_api.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.admin_api.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.admin_api.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-dep.yaml
@@ -89,6 +89,8 @@ spec:
             {{- toYaml .Values.alertmanager.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.alertmanager.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.alertmanager.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.alertmanager.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -173,6 +173,8 @@ spec:
             {{- toYaml .Values.alertmanager.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.alertmanager.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.alertmanager.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.alertmanager.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -138,6 +138,8 @@ spec:
             {{- toYaml .Values.compactor.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.compactor.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.compactor.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.compactor.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -89,6 +89,8 @@ spec:
             {{- toYaml .Values.distributor.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.distributor.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.distributor.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.distributor.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/gateway/gateway-dep.yaml
@@ -104,6 +104,10 @@ spec:
               protocol: TCP
           readinessProbe:
             {{- toYaml .readinessProbe | nindent 12 }}
+          livenessProbe:
+              {{- toYaml .livenessProbe | nindent 12 }}
+          startupProbe:
+              {{- toYaml .startupProbe | nindent 12 }}
           resources:
             {{- toYaml .resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -159,6 +159,8 @@ spec:
             {{- toYaml .Values.ingester.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.ingester.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.ingester.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.ingester.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/nginx/nginx-dep.yaml
@@ -77,6 +77,10 @@ spec:
           {{- end }}
           readinessProbe:
             {{- toYaml .Values.nginx.readinessProbe | nindent 12 }}
+          livenessProbe:
+              {{- toYaml .Values.nginx.livenessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.nginx.startupProbe | nindent 12 }}
           securityContext:
             {{- toYaml .Values.nginx.containerSecurityContext | nindent 12 }}
           volumeMounts:

--- a/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -76,6 +76,8 @@ spec:
             {{- toYaml .Values.overrides_exporter.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.overrides_exporter.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.overrides_exporter.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.overrides_exporter.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/querier/querier-dep.yaml
@@ -91,6 +91,8 @@ spec:
             {{- toYaml .Values.querier.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.querier.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.querier.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.querier.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -80,6 +80,8 @@ spec:
             {{- toYaml .Values.query_frontend.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.query_frontend.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.query_frontend.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.query_frontend.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -79,6 +79,8 @@ spec:
             {{- toYaml .Values.query_scheduler.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.query_scheduler.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.query_scheduler.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.query_scheduler.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -93,6 +93,8 @@ spec:
             {{- toYaml .Values.ruler.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.ruler.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.ruler.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.ruler.resources | nindent 12 }}
           securityContext:

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -156,6 +156,8 @@ spec:
             {{- toYaml .Values.store_gateway.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.store_gateway.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.store_gateway.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.store_gateway.resources | nindent 12 }}
           securityContext:


### PR DESCRIPTION
- Add startupProbe to admin-api deployment helm template
- Add startupProbe to alertmanager deployment and statefulset helm templates
- Add startupProbe to compactor deployment helm template
- Add startupProbe to distributor deployment helm template
- Add startupProbe and livenessProbe to gateway(nginx) deployment helm template
- Add startupProbe to ingester statefulset helm template
- Add startupProbe and livenessProbe to nginx deployment helm template
- Add startupProbe to overrides-exporter deployment helm template
- Add startupProbe to querier deployment helm template
- Add startupProbe to query-frontend deployment helm template
- Add startupProbe to query-scheduler deployment helm template
- Add startupProbe to ruler statefulset helm template
- Add startupProbe to store-gateway statefulset helm template
